### PR TITLE
This expression does not support system defined (and allowed) colors …

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@ else
 fi
 
 if [[ $TYPE != "force" ]]; then
-	OS_VERSION=`sw_vers -productVersion | egrep -o '10\.[0-9]+'`
+	OS_VERSION=`sw_vers -productVersion | egrep -o --color=never '10\.[0-9]+'`
 	if [[ $OS_VERSION == "10.12" ]]; then
 		echo "****"
 		echo "[WARNING]"


### PR DESCRIPTION
…for grep, e.g.:

14:31 [matthewcl-]: ~ $ cat ~/.bash_profile | grep GREP_OPTIONS
export GREP_OPTIONS='--color=always'

14:31 [matthewcl-]: ~ $ curl -s https://php-osx.liip.ch/install.sh | bash -s 5.6
****
Your version of OS X (10.11) is not supported, you need at least 10.6
Stopping installation...
If you think that's wrong, try
****
curl -o install.sh -s https://php-osx.liip.ch/install.sh | bash install.sh force
****

The error message shown looks like a very bad comparison but it's really just because of the colors defined at the system level...

In order to support a system that has this configured the --color=never must be specified in the grep command.